### PR TITLE
Fixed an issue with wrong column names for SWEET-Cat

### DIFF
--- a/src/pyasl/resBased/sweet_cat.py
+++ b/src/pyasl/resBased/sweet_cat.py
@@ -103,7 +103,7 @@ class SWEETCat(pp.PyAUpdateCycle):
     self.names = ['star', 'hd', 'ra', 'dec', 'vmag', 'ervmag', 'par', 'erpar',
              'parsource', 'teff', 'erteff', 'logg', 'erlogg', 'logglc',
              'erlogglc', 'vt', 'ervt', 'metal', 'ermetal', 'mass', 'ermass',
-             'author', 'link', 'source', 'update', 'comment1', 'comment2']
+             'author', 'source', 'update', 'comment']
 
     # Check whether data file exists
     self._fs = pp.PyAFS()


### PR DESCRIPTION
Since there are more columns provided in the file uploaded to the webpage of SWEET-Cat, the columns were named slightly wrong. This fixes the issue, and the names are now correct.