### PR TITLE
Fix #22: Remove numpy dependency on info setup.py commands. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,21 +7,18 @@ def require_numpy():
     """Check the commands if numpy required to build extensions.
     Return a boolean value for whether or not numpy is required.
     """
-    print("checking numpy")
     info_commands = ['--help-commands', '--name', '--version', '-V',
                      '--fullname', '--author', '--author-email',
                      '--maintainer', '--maintainer-email', '--contact',
                      '--contact-email', '--url', '--license', '--description',
                      '--long-description', '--platforms', '--classifiers',
                      '--keywords', '--provides', '--requires', '--obsoletes']
-    # Add commands that do more than print info, but also don't need Cython and
-    # template parsing.
+    # Add commands that do more than print info, but also don't need extensions
     info_commands.extend(['egg_info', 'install_egg_info', 'rotate'])
 
     for command in info_commands:
         if command in sys.argv[1:]:
            return False
-
     return True
 
 if require_numpy():

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,39 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-try:
-  from numpy.distutils.core import setup, Command
-except(ImportError):
-  print("Please install 'numpy' first.")
-  
-import glob
 import sys
+
+# Inspired by scipy's setup.py
+def require_numpy():
+    """Check the commands if numpy required to build extensions.
+    Return a boolean value for whether or not numpy is required.
+    """
+    print("checking numpy")
+    info_commands = ['--help-commands', '--name', '--version', '-V',
+                     '--fullname', '--author', '--author-email',
+                     '--maintainer', '--maintainer-email', '--contact',
+                     '--contact-email', '--url', '--license', '--description',
+                     '--long-description', '--platforms', '--classifiers',
+                     '--keywords', '--provides', '--requires', '--obsoletes']
+    # Add commands that do more than print info, but also don't need Cython and
+    # template parsing.
+    info_commands.extend(['egg_info', 'install_egg_info', 'rotate'])
+
+    for command in info_commands:
+        if command in sys.argv[1:]:
+           return False
+
+    return True
+
+if require_numpy():
+    try:
+      from numpy.distutils.core import setup, Command
+    except(ImportError):
+      print("Please install 'numpy' first.")
+else:
+    from setuptools import setup
+    from distutils.cmd import Command
+
+import glob
 import re
 sys.path.append("src")
 from PyA_Version import PyA_Version
@@ -162,8 +189,8 @@ class WithExtCommand(Command):
 
 
 
-if sdist:  
-  
+if sdist:
+
   manin = open("MANIFEST.in_template").readlines()
   # Add package data to Manifest.in
   for p in packages:
@@ -173,7 +200,7 @@ if sdist:
     path = p.replace('.', '/').replace("PyAstronomy", "src")
     for d in package_data[p]:
       manin.append("include "+path+"/"+d+"\n")
-  
+
   # Add documentation in Manifest.in
   for p in packages:
     # Regular expression ignoring sub-packages.
@@ -183,7 +210,7 @@ if sdist:
     if r is not None:
       manin.append("# Documentation for: "+p+"\n")
       manin.append("recursive-include src/doc/"+r.group(1)+"Doc *.rst *.png\n")
-  
+
   open("MANIFEST.in", 'w').writelines(manin)
 
 
@@ -210,5 +237,4 @@ if not withExt:
   for e in _ext_modules:
     print("    \""+e.name+"\", Sources: ", e.sources)
   print("  USE 'python setup.py --with-ext install' to build external modules")
-  print("") 
-  
+  print("")


### PR DESCRIPTION
This checks what setup command is passed. If it is one of the info commands, (e.g. "egg_info") then `numpy` is not required and so is not imported for dependency determination .
Allows dependency determination without `numpy`, thus resolving #22, allowing pip to install `PyAstronomy` and `numpy` at the same time.

Inspired by the `setup.py` file for `scipy`. 

I have only tested it locally using a fresh conda enviroment (without `numpy` installed).

Running  ` pip install -e .  `   fails.
```
$ pip install -e . --no-cache              
Obtaining file:///home/jneal/Phd/Codes/Repos/PyAstronomy
Installing collected packages: PyAstronomy
  Running setup.py develop for PyAstronomy
    Complete output from command /home/jneal/miniconda3/envs/test_pyast/bin/python -c "import setuptools, tokenize;__file__='/home/jneal/Phd/Codes/Repos/PyAstronomy/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps:
    Please install 'numpy' first.
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/jneal/Phd/Codes/Repos/PyAstronomy/setup.py", line 177, in <module>
        class WithExtCommand(Command):
    NameError: name 'Command' is not defined
    
    ----------------------------------------
Command "/home/jneal/miniconda3/envs/test_pyast/bin/python -c "import setuptools, tokenize;__file__='/home/jneal/Phd/Codes/Repos/PyAstronomy/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps" failed with error code 1 in /home/jneal/Phd/Codes/Repos/PyAstronomy/

```

but with this PR ` pip install -e .  numpy --no-cache` works.

```
$ pip install -e . numpy --no-cache
Obtaining file:///home/jneal/Phd/Codes/Repos/PyAstronomy
Collecting numpy
  Downloading numpy-1.12.1-cp34-cp34m-manylinux1_x86_64.whl (16.8MB)
    100% |████████████████████████████████| 16.8MB 906kB/s 
Installing collected packages: numpy, PyAstronomy
  Running setup.py develop for PyAstronomy
Successfully installed PyAstronomy numpy-1.12.1
```

When this is pushed to pypi this should allow `PyAstronomy` to be placed alongside `numpy` in a `requirements.txt` and be installed on fresh environments.