### PR TITLE
Make KeplerEllipseModel work with fitEMCEE method

### DIFF
--- a/src/funcFit/onedfit.py
+++ b/src/funcFit/onedfit.py
@@ -1705,6 +1705,7 @@ class OneDFit(_OndeDFitParBase, _PyMCSampler):
       # likelihood function at this step:
       pdf = prior_sum
       if pdf == -np.inf:
+        print("e prior is ", priors["e"](ps, "e"))
         return pdf
       # Likelihood
       pdf += likeli(fpns, values)
@@ -1778,8 +1779,8 @@ class OneDFit(_OndeDFitParBase, _PyMCSampler):
                              pnames=np.array(fpns, dtype=np.unicode_))
     
     if toMD:
-      # Set to lowest-deviance solution
-      indimin = np.argmin(self.emceeSampler.lnprobability)
+      # Set to lowest-deviance (highest probability) solution
+      indimin = np.argmax(self.emceeSampler.lnprobability)
       for i, p in enumerate(self.freeParamNames()):
         self[p] = self.emceeSampler.flatchain[indimin, i] 
     

--- a/src/funcFit/onedfit.py
+++ b/src/funcFit/onedfit.py
@@ -1705,7 +1705,6 @@ class OneDFit(_OndeDFitParBase, _PyMCSampler):
       # likelihood function at this step:
       pdf = prior_sum
       if pdf == -np.inf:
-        print("e prior is ", priors["e"](ps, "e"))
         return pdf
       # Likelihood
       pdf += likeli(fpns, values)

--- a/src/funcFit/onedfit.py
+++ b/src/funcFit/onedfit.py
@@ -1696,11 +1696,18 @@ class OneDFit(_OndeDFitParBase, _PyMCSampler):
     def lnpostdf(values):
       # Parameter-Value dictionary
       ps = dict(zip(fpns, values))
-      # Likelihood
-      pdf = likeli(fpns, values)
-      # Add prior information
+      # Check prior information
+      prior_sum = 0
       for name in fpns:
-        pdf += priors[name](ps, name)
+        prior_sum += priors[name](ps, name)
+      # If log prior is negative infinity, parameters
+      # are out of range, so no need to evaluate the
+      # likelihood function at this step:
+      pdf = prior_sum
+      if pdf == -np.inf:
+        return pdf
+      # Likelihood
+      pdf += likeli(fpns, values)
       # Add information from potentials
       for p in pots:
         pdf += p(ps)


### PR DESCRIPTION
I found that the `KeplerEllipseModel` code would not work well with the `fitEMCEE` method, because it would try to evaluate orbits with non-physical orbital parameters, such as e < 0 or e > 1.  Even if restrictions are set on these parameters with `setRestriction`, these restrictions are enforced only after the chi-squared evaluation (via the penalty factor), so the code would still try to evaluate the orbit first, returning an error, and `fitEMCEE` would fail, reporting `ValueError: lnprob returned NaN`.

The solution is twofold.  First, implement limits on these parameters (e.g. eccentricity and various angles in the orbit) via defining priors.  Following the recommended [emcee method for parameter limits](http://dan.iel.fm/emcee/current/user/faq/#parameter-limits), these priors return `-numpy.inf` for the log probability if parameters are out of bounds.   Second, I have modified the `fitEMCEE` code slightly so that it checks the priors before trying to evaluate a given orbit, and if the prior sum is `-numpy.inf`, it short-circuits and simply returns that value.  In addition to avoiding unphysical parameters, this should also be more efficient overall, avoiding unnecessary function evaluations in cases where the prior probability is zero.

Unrelated to the above, I found that the code for `fitEMCEE` was setting the fitting object to the *lowest* probability solution rather than the highest at the end of a run, so I fixed that. 

If you think the above changes are useful, I could also make some modest changes to the docs for fitEMCEE to show how to set parameter limits in this way. 