### PR TITLE
Use setup from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-from distutils.core import setup, Command
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+from distutils.core import Command
+
   
 import glob
 import sys


### PR DESCRIPTION
In commit 04a4f45015bc you added the` install_requires` keyword to setup.py. This is from setuptools only so results in a UserWarning. (also seen in #32)
```
... distutils/dist.py:261:  UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
```
Some suggest to use setup from  setuptools instead of distutils   e.g. [adding-install-requires](https://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package)
I have made the change here with the fallback to use distutils' setup.

I do not know how/if this reacts with the other distutils imports you use, `Command` and `Extension`

Although when building with setuptools it changes the version numbering
```
site-packages/setuptools/dist.py:349: UserWarning: Normalizing '0.13.0beta' to '0.13.0b0'
  normalized_version,
```
(At least on the latest master)