### PR TITLE
Mention installation with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Installation
 
   If you specify the `--with-ext` flag, setup will try to
   compile non-Python modules. This is not mandatory.
+  
+  Another option is to install it with pip, i.e.
+  `pip install git+https://github.com/sczesla/PyAstronomy.git`
 
 Documentation and further information
 -------------------------------------


### PR DESCRIPTION
I prefer pip over setup.py for module installation and think that it should be at least mentioned for beginners