### PR TITLE
Emphasis ignoring timezone component of datetime

### DIFF
--- a/src/pyasl/asl/astroTimeLegacy.py
+++ b/src/pyasl/asl/astroTimeLegacy.py
@@ -1009,7 +1009,7 @@ def jdcnv(dt):
     Parameters
     ----------
     dt : DateTime object
-        The date.
+        The date. This is interpreted as UTC and the timezone component is not considered.
     
     Returns
     -------


### PR DESCRIPTION
Usually the `tzinfo` should be considered. If not given, the user should be made aware of that.