### PR TITLE
Add and classify package with licence.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,8 @@ setup(cmdclass={"with-ext": WithExtCommand},
       package_data=package_data,
       author='PyA group',
       author_email='stefan.czesla@hs.uni-hamburg.de',
+      licence='MIT Licence',
+      classifiers=["License :: OSI Approved :: MIT License"],
       )
 
 if not withExt:


### PR DESCRIPTION
This should allow other services to identify the license of `PyAstronomy`.

e.g. currently `pyup.io` shows this
![pyup](https://user-images.githubusercontent.com/10076879/44724022-85847900-aac9-11e8-99ee-0ebb813c3e0e.png)

